### PR TITLE
Modified Accuvant bog posts to the new Optive urls

### DIFF
--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     => [
         [ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
         [ 'OSVDB', '3106'],
-        [ 'URL', 'http://www.accuvant.com/blog/2012/11/13/owning-computers-without-shell-access' ],
+        [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ],
         [ 'URL', 'http://sourceforge.net/projects/smbexec/' ],
         [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
       ]

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'=> MSF_LICENSE,
       'References' => [
         [ 'URL', 'http://sourceforge.net/projects/smbexec' ],
-        [ 'URL', 'http://www.accuvant.com/blog/2012/11/13/owning-computers-without-shell-access' ]
+        [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ]
       ]
     ))
 

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'https://docs.oracle.com/javase/8/docs/technotes/guides/jmx/JMX_1_4_specification.pdf'],
-          ['URL', 'http://www.accuvant.com/blog/exploiting-jmx-rmi'],
+          ['URL', 'https://www.optiv.com/blog/exploiting-jmx-rmi'],
           ['CVE', '2015-2342']
         ],
       'Platform'       => 'java',

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
           [ 'OSVDB', '3106'],
           [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ],
-          [ 'URL', 'http://www.accuvant.com/blog/2012/11/13/owning-computers-without-shell-access' ],
+          [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ],
           [ 'URL', 'http://sourceforge.net/projects/smbexec/' ]
         ],
       'Payload'        =>

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'       => [
         [ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
         [ 'OSVDB', '3106'],
-        [ 'URL', 'http://www.accuvant.com/blog/2012/11/13/owning-computers-without-shell-access' ],
+        [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ],
         [ 'URL', 'http://sourceforge.net/projects/smbexec/' ],
         [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
       ]


### PR DESCRIPTION
I was using the java_jmx_server and tried to read the references, found that the Accuvant posts now belong to Optiv. Making the changes for future users.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use modules/auxiliary/admin/smb/psexec_ntdsgrab`
- [ ] `info`
- [ ] **Verify** the blog post directs to Optiv
- [ ] **Repeat for**
----modules/auxiliary/admin/smb/psexec_command
----modules/exploits/multi/misc/java_jmx_server
----modules/exploits/windows/smb/psexec
----modules/exploits/windows/smb/psexec_psh

